### PR TITLE
Fix spec rake task pattern for files

### DIFF
--- a/serverspec/Rakefile
+++ b/serverspec/Rakefile
@@ -2,7 +2,7 @@ require 'rake'
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.pattern = 'spec/*/*_spec.rb'
+  t.pattern = 'spec/*_spec.rb'
 end
 
 task :default => :spec


### PR DESCRIPTION
Cloning the repo and running "rake" against the serverspec folder doesn't work. Propose the following change as it appears the *_spec.rb files are not qualifying for the pattern.

Output for me before change:

```
~/tmp/serverspec_examples/serverspec (master u=)$ rake
/Users/dh015921/.rvm/rubies/ruby-1.9.3-p545/bin/ruby -I/Users/dh015921/.rvm/gems/ruby-1.9.3-p545/gems/rspec-support-3.1.2/lib:/Users/dh015921/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-3.1.7/lib /Users/dh015921/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-3.1.7/exe/rspec --pattern spec/\*/\*_spec.rb
No examples found.


Finished in 0.00028 seconds (files took 0.04888 seconds to load)
0 examples, 0 failures
```
